### PR TITLE
Add Django 2.x compatibility

### DIFF
--- a/django_apscheduler/models.py
+++ b/django_apscheduler/models.py
@@ -27,7 +27,7 @@ class DjangoJobExecution(models.Model):
     ERROR = u"Error!"
     SUCCESS = u"Executed"
 
-    job = models.ForeignKey(DjangoJob)
+    job = models.ForeignKey(DjangoJob, on_delete=models.CASCADE)
     status = models.CharField(max_length=50, choices=[
         [x, x]
         for x in [ADDED, SENT, MAX_INSTANCES, MISSED, MODIFIED,

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
 appdirs==1.4.3
 APScheduler==3.3.1
-Django==1.11.1
+Django==2.0.0
 -e git+git@github.com:sallyruthstruik/django-apscheduler.git@9cb356e03c84850734eacadea946ccc6d24c69d2#egg=django_apscheduler
 funcsigs==1.0.2
 futures==3.1.1

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ deps = pytest
        pytest-django
        pytest-cov
        mock
+       py27: Django<2.0.0
 commands =
        python setup.py develop
        pytest --cov=django_apscheduler


### PR DESCRIPTION
The `on_delete` argument for ForeignKey and OneToOneField is now required in models and migrations. 

https://docs.djangoproject.com/en/2.0/releases/2.0/#features-removed-in-2-0