### PR TITLE
Update get_next_run_time to handle Paused jobs

### DIFF
--- a/django_apscheduler/jobstores.py
+++ b/django_apscheduler/jobstores.py
@@ -76,7 +76,7 @@ class DjangoJobStore(BaseJobStore):
     @ignore_database_error()
     def get_next_run_time(self):
         try:
-            return deserialize_dt(DjangoJob.objects.first().next_run_time)
+            return deserialize_dt(DjangoJob.objects.filter(next_run_time__isnull=False).earliest('next_run_time').next_run_time)
         except AttributeError:  # no active jobs
             return None
 


### PR DESCRIPTION
Paused jobs have next_run_time of None.

This change makes django_apscheduler.jobstores looks a bit more like apscheduler.jobstores.sqlalchemy which filters out the nulls and picks the earliest next_run_time.