### PR TITLE
Add model manager for deleting old job executions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: xenial
+
 language: python
 python: 3.6
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ format for displaying runtime timestamps in the Django admin site using ``APSCHE
   It provides the following interface:
   ![](http://dl3.joxi.net/drive/2017/05/19/0003/0636/258684/84/bebc279ecd.png)
 
+*  Old job executions can be deleted with:
+  ```python
+    DjangoJobExecution.objects.delete_old_job_executions(604_800)  # Delete job executions older than 7 days
+  ```
 
 * Register any jobs as you would normally. Note that if you haven't set ``DjangoJobStore`` as the ``'default'`` job store,
   you'll need to include ``jobstore='djangojobstore'`` in your ``scheduler.add_job`` calls.

--- a/django_apscheduler/models.py
+++ b/django_apscheduler/models.py
@@ -60,15 +60,15 @@ class DjangoJob(models.Model):
 
 
 class DjangoJobExecutionManager(models.Manager):
-    def delete_old_job_executions(self, max_task_age):
+    def delete_old_job_executions(self, max_age):
         """
         Delete old job executions from the database.
 
-        :param max_task_age: The maximum age (in seconds). Executions that are older
+        :param max_age: The maximum age (in seconds). Executions that are older
         than this will be deleted.
         """
         self.filter(
-            run_time__lte=now() - timedelta(seconds=max_task_age),
+            run_time__lte=now() - timedelta(seconds=max_age),
         ).delete()
 
 

--- a/django_apscheduler/models.py
+++ b/django_apscheduler/models.py
@@ -1,10 +1,14 @@
 # coding=utf-8
+from datetime import timedelta
+
 from django.db import models, connection
 from django.utils.safestring import mark_safe
+from django.utils.timezone import now
 import time
 import logging
 
 LOGGER = logging.getLogger("django_apscheduler")
+
 
 class DjangoJobManager(models.Manager):
     """
@@ -55,6 +59,19 @@ class DjangoJob(models.Model):
         ordering = ('next_run_time', )
 
 
+class DjangoJobExecutionManager(models.Manager):
+    def delete_old_job_executions(self, max_task_age):
+        """
+        Delete old job executions from the database.
+
+        :param max_task_age: The maximum age (in seconds). Executions that are older
+        than this will be deleted.
+        """
+        self.filter(
+            run_time__lte=now() - timedelta(seconds=max_task_age),
+        ).delete()
+
+
 class DjangoJobExecution(models.Model):
     ADDED = u"Added"
     SENT = u"Started execution"
@@ -82,6 +99,8 @@ class DjangoJobExecution(models.Model):
 
     exception = models.CharField(max_length=1000, null=True)
     traceback = models.TextField(null=True)
+
+    objects = DjangoJobExecutionManager()
 
     def html_status(self):
         m = {

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,14 +1,14 @@
-appdirs==1.4.3
-APScheduler==3.3.1
-Django==2.0.0
+appdirs~=1.4.3
+APScheduler~=3.3.1
+Django~=2.0.0
 -e git+git@github.com:sallyruthstruik/django-apscheduler.git@9cb356e03c84850734eacadea946ccc6d24c69d2#egg=django_apscheduler
-funcsigs==1.0.2
-futures==3.1.1
-packaging==16.8
-py==1.4.33
-pyparsing==2.2.0
-pytest==3.0.7
-pytest-django==3.1.2
-pytz==2017.2
-six==1.10.0
-tzlocal==1.4
+funcsigs~=1.0.2
+futures~=3.1.1
+packaging~=16.8
+py~=1.4.33
+pyparsing~=2.2.0
+pytest~=3.0.7
+pytest-django~=3.1.2
+pytz~=2017.2
+six~=1.10.0
+tzlocal~=1.4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,32 @@
 import pytest
+import pytz
+from apscheduler.executors.debug import DebugExecutor
+from apscheduler.schedulers.base import BaseScheduler
 from django.conf import settings
+
+from django_apscheduler.jobstores import DjangoJobStore
+
+
+class DebugScheduler(BaseScheduler):
+
+    def shutdown(self, wait=True):
+        pass
+
+    def wakeup(self):
+        self._process_jobs()
+
+
+def job(*args, **kwargs):
+    print("JOB")
+
+
+@pytest.fixture
+def scheduler():
+    scheduler = DebugScheduler(timezone=pytz.timezone("Europe/Moscow"))
+    scheduler.add_jobstore(DjangoJobStore())
+    scheduler.add_executor(DebugExecutor())
+
+    return scheduler
 
 
 @pytest.fixture

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,34 @@
+import datetime
+import logging
+
+from apscheduler.events import JobExecutionEvent, JobSubmissionEvent
+from pytz import utc
+
+from django_apscheduler.jobstores import register_events
+from django_apscheduler.models import DjangoJobExecution
+from tests.conftest import job
+
+logging.basicConfig()
+
+
+def test_delete_old_job_executions(db, scheduler):
+    register_events(scheduler)
+    scheduler.add_job(job, trigger="interval", seconds=1, id="job_1")
+    scheduler.add_job(job, trigger="interval", seconds=1, id="job_2")
+
+    scheduler.start()
+
+    now = datetime.datetime.now(utc)
+    one_second_ago = now - datetime.timedelta(seconds=1)  # Simulate
+
+    scheduler._dispatch_event(JobExecutionEvent(4096, "job_1", None, one_second_ago))
+    scheduler._dispatch_event(JobExecutionEvent(4096, "job_2", None, now))
+
+    scheduler._dispatch_event(JobSubmissionEvent(32768, "job_1", None, [one_second_ago]))
+    scheduler._dispatch_event(JobSubmissionEvent(32768, "job_2", None, [now]))
+
+    assert DjangoJobExecution.objects.count() == 2
+
+    DjangoJobExecution.objects.delete_old_job_executions(1)
+
+    assert DjangoJobExecution.objects.count() == 1


### PR DESCRIPTION
Adds a new model manager for `DjangoJobExecution` to allow deleting old job executions, which can tally up quite quickly if multiple jobs have been scheduled with a high level of frequency.

- Not sure why GitHub generated the large diff on the README: I only added one bullet point to describe the new feature.
- I had to move the tests around a bit so that we could re-use some fixtures and mock objects centrally from `conftest.py`.