### PR TITLE
Format "next run at:" time according to settings

### DIFF
--- a/django_apscheduler/models.py
+++ b/django_apscheduler/models.py
@@ -7,6 +7,8 @@ from django.utils.timezone import now
 import time
 import logging
 
+from django_apscheduler import util
+
 LOGGER = logging.getLogger("django_apscheduler")
 
 
@@ -52,7 +54,7 @@ class DjangoJob(models.Model):
     objects = DjangoJobManager()
 
     def __str__(self):
-        status = 'next run at: %s' % self.next_run_time if self.next_run_time else 'paused'
+        status = 'next run at: %s' % util.localize(self.next_run_time) if self.next_run_time else 'paused'
         return '%s (%s)' % (self.name, status)
 
     class Meta:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2158203/67016525-98f10a00-f0f8-11e9-8bd3-4bc9733cb276.png)

The time formats in the admin are currently inconsistent, because one of them ins rendered in `models.py` with djangos default, the other one is rendered correctly in `admin.py`. This unifies the formats.