### PR TITLE
fix issue #41

### DIFF
--- a/django_apscheduler/admin.py
+++ b/django_apscheduler/admin.py
@@ -33,6 +33,8 @@ class DjangoJobAdmin(admin.ModelAdmin):
         return super(DjangoJobAdmin, self).get_queryset(request)
 
     def next_run_time_sec(self, obj):
+        if obj.next_run_time is None:
+            return "(paused)"
         return util.localize(obj.next_run_time)
 
     def average_duration(self, obj):


### PR DESCRIPTION
If a job is paused, when django tries to format the next run time, it receives None because it is paused.
This check displays the `(paused)` string in place of the next run time instead of causing AttributeError 'NoneType' object has no attribute 'strftime'