### PR TITLE
Put type annotation comment right after function definition

### DIFF
--- a/django_apscheduler/jobstores.py
+++ b/django_apscheduler/jobstores.py
@@ -222,6 +222,7 @@ def register_events(scheduler, result_storage=None):
 
 
 def register_job(scheduler, *a, **k):
+    # type: (BaseScheduler)->callable
     """
 
     Helper decorator for job registration.
@@ -240,7 +241,6 @@ def register_job(scheduler, *a, **k):
 
     :param a, k: Params, will be passed to scheduler.add_job method. See :func:`BaseScheduler.add_job`
     """
-    # type: (BaseScheduler)->callable
 
     def inner(func):
         k.setdefault("id", "{}.{}".format(func.__module__, func.__name__))


### PR DESCRIPTION
Otherwise pylint fails with
```
[E0001(syntax-error), ] Cannot import 'django_apscheduler.jobstores' due to syntax error 'misplaced type annotation (<unknown>, line 243)'
```