### PR TITLE
Deprecate 'register_events'

### DIFF
--- a/django_apscheduler/docs/changelog.md
+++ b/django_apscheduler/docs/changelog.md
@@ -26,8 +26,9 @@ This changelog is used to track all major changes to django_apscheduler.
 - Switch to using `BigAutoField` for `DjangoJobExecution`'s primary keys. This should prevent running out of usable
   ID's for deployments with a very large number of job executions in the database (Resolves [#36](https://github.com/jarekwg/django-apscheduler/issues/36)).
 - Implement `DjangoJob.shutdown()` method to close database connection when scheduler is shut down.
-- **BREAKING CHANGE:** Removed `jobstores.register_events`. Calling this method is no longer necessary as the
-  `DjangoJobStore` will automatically register for events that it cares about when the scheduler is started.
+- `jobstores.register_events` has been deprecated and will be removed in a future release. Calling this method is no
+  longer necessary as the `DjangoJobStore` will automatically register for events that it cares about when the scheduler
+  is started.
 - Ensure that Django and APScheduler always use the same timezones when passing datetimes between the two.
 - Use the configured scheduler's locking mechanism to keep the creation of `DjangoJobExecution` in sync with APScheduler
   events.

--- a/django_apscheduler/jobstores.py
+++ b/django_apscheduler/jobstores.py
@@ -324,6 +324,16 @@ class DjangoJobStore(DjangoResultStoreMixin, BaseJobStore):
         return f"<{self.__class__.__name__}(pickle_protocol={self.pickle_protocol})>"
 
 
+def register_events(scheduler, result_storage=None):
+    # TODO: Remove this deprecated function in release 0.5
+    # DjangoResultStoreMixin now takes care of registering for events automatically when the scheduler is started.
+    warnings.warn(
+        "'register_events' is deprecated since version 0.4.0. Please remove all references from your code.",
+        DeprecationWarning,
+    )
+    pass
+
+
 def register_job(scheduler: BaseScheduler, *a, **k) -> callable:
     """
     Helper decorator for job registration.


### PR DESCRIPTION
Deprecate the `register_events` method, instead of removing it outright, to avoid breakage and give users of django_apscheduler time to adapt their code.