### PR TITLE
Don't mute database-related errors

### DIFF
--- a/django_apscheduler/docs/changelog.md
+++ b/django_apscheduler/docs/changelog.md
@@ -34,8 +34,10 @@ This changelog is used to track all major changes to django_apscheduler.
   events.
 - Update README on recommended usage, which includes using a `BlockingScheduler` with a custom Django management command
   instead of running a `BackgroundScheduler` directly in a Django application.
+- Remove `ignore_database_error` decorator. All database errors will be raised so that users can decide on the best
+  course of action for their specific use case (Resolves [#79](https://github.com/jarekwg/django-apscheduler/issues/79)).
 
 **Fixes**
 
 - Fix PEP8 code formatting violations.
-- Implement locking mechanism to prevent duplicate `DjangoJobExecution`s from being created (Resolves [#28](https://github.com/jarekwg/django-apscheduler/issues/28), [#30](https://github.com/jarekwg/django-apscheduler/issues/30), [#44](https://github.com/jarekwg/django-apscheduler/issues/44)).
+- Implement locking mechanism to prevent duplicate `DjangoJobExecution`s from being created (Fixes [#28](https://github.com/jarekwg/django-apscheduler/issues/28), [#30](https://github.com/jarekwg/django-apscheduler/issues/30), [#44](https://github.com/jarekwg/django-apscheduler/issues/44)).


### PR DESCRIPTION
Removes the `ignore_database_error ` decorator responsible for muting database-related errors.

I suspect that this was introduced to deal with various edge cases associated with using a `BackgroundScheduler` in a diverse range of deployments at the time.

Now that we are recommending a `BlockingScheduler` that can be used with django_apscheduler without the need for any additional globally mutually exclusive locks on the job store (which will be an implementation detail that differs for each use case anyway) we can probably do await with it and raise all DB exceptions so that users can deal with them themselves.

Fixes #79.