### PR TITLE
Remove arbitrary DB pings.

### DIFF
--- a/django_apscheduler/docs/changelog.md
+++ b/django_apscheduler/docs/changelog.md
@@ -36,6 +36,8 @@ This changelog is used to track all major changes to django_apscheduler.
   instead of running a `BackgroundScheduler` directly in a Django application.
 - Remove `ignore_database_error` decorator. All database errors will be raised so that users can decide on the best
   course of action for their specific use case (Resolves [#79](https://github.com/jarekwg/django-apscheduler/issues/79)).
+- Remove `DjangoJobManager`: users should be allowed to manage the DB connection themselves based on their
+  implementation-specific use case. See the official Django recommendations at: https://code.djangoproject.com/ticket/21597#comment:29.
 
 **Fixes**
 


### PR DESCRIPTION
Removes an apparent workaround that attempts to keep DB connections alive.

There are various officially recognised ways of dealing with DB timeouts, and subjecting all users of django_apscheduler to random DB pings is probably unreasonable (see https://code.djangoproject.com/ticket/21597#comment:29 on why this is a bad approach).

Users should be encouraged to follow Django's recommendations on [persistent connections](https://docs.djangoproject.com/en/dev/ref/databases/#persistent-connections) instead and, if that is not enough, consider using a connection pool manager like [pgbouncer](http://www.pgbouncer.org/).

